### PR TITLE
fix flickering with image content

### DIFF
--- a/Swiper.js
+++ b/Swiper.js
@@ -206,14 +206,21 @@ class Swiper extends React.Component {
     }
   }
 
-  setCardIndex = (newCardIndex, swipedAllCards) => {
-    this.setState({
-        firstCardIndex: newCardIndex,
-        secondCardIndex: this.calculateSecondCardIndex(newCardIndex),
-        previousCardIndex: this.calculatePreviousCardIndex(newCardIndex),
-        swipedAllCards: swipedAllCards
-      }, this.resetPanAndScale)
-  };
+
+    setCardIndex = (newCardIndex, swipedAllCards) => {
+      this.setState({
+          firstCardIndex: newCardIndex,
+          secondCardIndex: newCardIndex,
+      }, () => {
+        setTimeout(() =>{
+          this.setState({
+            secondCardIndex: this.calculateSecondCardIndex(newCardIndex),
+            previousCardIndex: this.calculatePreviousCardIndex(newCardIndex),
+            swipedAllCards: swipedAllCards
+          }, this.resetPanAndScale)
+        }, 50)
+      })
+    };
 
   resetPanAndScale = () => {
     this.state.pan.setValue({ x: 0, y: 0 })


### PR DESCRIPTION
I have content with one big image and swiping caused a flickering effect when it is rendering new card. 

My solution is to set first both `firstCardIndex` and `secondCardIndex` to `newCardIndex` in `setCardIndex` and after short delay (50ms) update `secondCardIndex` to proper value. This seemed to fix the problem.

Thanks for the great plugin!