### PR TITLE
Added swipe labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ npm install react-native-deck-swiper --save
 
 | Props    | type   | description                                                                                             | required | default                          |
 |:----------|:--------|:---------------------------------------------------------------------------------------------------------|:----------------------------------|:------------|
-| cards    | array | array of data for the cards to be rendered | required                         |
-| renderCard    | func(cardData) | function to render the card based on the data | required                         |
+| cards    | array | array of data for the cards to be rendered | required |
+| renderCard    | func(cardData) | function to render the card based on the data | required |
 | onSwipedAll| func | function to be called when all cards have been swiped | | () => {} |
 | onSwiped | func | function to be called when a card is swiped. it receives the swiped card index | | (cardIndex) => {} |
 | onSwipedLeft | func | function to be called when a card is swiped left. it receives the swiped card index | | (cardIndex) => {} |
@@ -57,14 +57,50 @@ npm install react-native-deck-swiper --save
 | outputRotationRange | array | rotation values for the x values in inputRotationRange |  ["-10deg", "0deg", "10deg"] |
 
 ### Opacity animation props
-
 | Props    | type   | description                                                                                             | default                          |
 |:----------|:--------|:---------------------------------------------------------------------------------------------------------|:----------------------------------|
-| animateOpacity| bool | animate opacity | false |
-| inputOpacityRangeX | array | pan x opacity input range | [-width / 2, -width / 3, 0, width / 3, width / 2] |
-| outputOpacityRangeX | array | opacity values for the values in inputOpacityRange | [0.8, 1, 1, 1, 0.8] |
-| inputOpacityRangeY | array | pan y opacity input range | [-height / 2, -height / 3, 0, height / 3, height / 2]
-| outputOpacityRangeY | array | opacity values for the values in inputOpacityRange | [0.8, 1, 1, 1, 0.8] |
+| animateCardOpacity| bool | animate card opacity | false |
+| inputCardOpacityRangeX | array | pan x card opacity input range | [-width / 2, -width / 3, 0, width / 3, width / 2] |
+| outputCardOpacityRangeX | array | opacity values for the values in inputCardOpacityRangeX | [0.8, 1, 1, 1, 0.8] |
+| inputCardOpacityRangeY | array | pan y card opacity input range | [-height / 2, -height / 3, 0, height / 3, height / 2]
+| outputCardOpacityRangeY | array | opacity values for the values in inputCardOpacityRangeY | [0.8, 1, 1, 1, 0.8] |
+| animateOverlayLabelsOpacity| bool | animate card overlay labels opacity | false |
+| inputOverlayLabelsOpacityRangeX | array | pan x overlay labels opacity input range | [-width / 3, -width / 4, 0, width / 4, width / 3] |
+| outputOverlayLabelsOpacityRangeX | array | opacity values for the values in inputOverlayLabelsOpacityRangeX | [1, 0, 0, 0, 1] |
+| inputOverlayLabelsOpacityRangeY | array | pan x overlay labels opacity input range | [-height / 4, -height / 5, 0, height / 5, height / 4] |
+| outputOverlayLabelsOpacityRangeY | array | opacity values for the values in inputOverlayLabelsOpacityRangeY | [1, 0, 0, 0, 1] |
+
+2 steps of inputOverlayLabelsOpacityRangeX and inputOverlayLabelsOpacityRangeY should match horizontalThreshold and verticalThreshold, respectively.
+
+### Swipe overlay labels
+| Props    | type   | description                                                                                             | default                          |
+|:----------|:--------|:---------------------------------------------------------------------------------------------------------|:----------------------------------|
+| overlayLabels| object | swipe labels info | {
+  bottom: {
+    title: 'BLEAH',
+    swipeColor: '#946C8C',
+    backgroundOpacity: '0.75',
+    fontColor: '#FFF'
+  },
+  left: {
+    title: 'NOPE',
+    swipeColor: '#4A2359',
+    backgroundOpacity: '0.75',
+    fontColor: '#FFF'
+  },
+  right: {
+    title: 'LIKE',
+    swipeColor: '#FA9F8C',
+    backgroundOpacity: '0.75',
+    fontColor: '#FFF'
+  },
+  top: {
+    title: 'SUPER LIKE',
+    swipeColor: '#FFC37B',
+    backgroundOpacity: '0.75',
+    fontColor: '#FFF'
+  }
+} |
 
 ### Swipe back animation props
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ npm install react-native-deck-swiper --save
 ### Swipe overlay labels
 | Props    | type   | description                                                                                             | default                          |
 |:----------|:--------|:---------------------------------------------------------------------------------------------------------|:----------------------------------|
-| overlayLabels| object | swipe labels info | {
+| overlayLabels| object | swipe labels info | see below |
+```javascript
+{
   bottom: {
     title: 'BLEAH',
     swipeColor: '#946C8C',
@@ -100,7 +102,8 @@ npm install react-native-deck-swiper --save
     backgroundOpacity: '0.75',
     fontColor: '#FFF'
   }
-} |
+}
+```
 
 ### Swipe back animation props
 

--- a/Swiper.js
+++ b/Swiper.js
@@ -276,7 +276,7 @@ class Swiper extends React.Component {
   };
 
   onSwipedCallbacks = (swipeDirectionCallback, swipedAllCards) => {
-    let previousCardIndex = this.state.firstCardIndex;
+    const previousCardIndex = this.state.firstCardIndex;
     this.props.onSwiped(previousCardIndex);
 
     swipeDirectionCallback(previousCardIndex);
@@ -360,13 +360,13 @@ class Swiper extends React.Component {
         };
       break;
     }
-    let opacity = this.props.animateOverlayLabelsOpacity ? this.interpolateOverlayLabelsOpacity() : 1;
+    const opacity = this.props.animateOverlayLabelsOpacity ? this.interpolateOverlayLabelsOpacity() : 1;
     return [styles.overlayLabelWrapper, dynamicStyles, {opacity}];
   }
 
   calculateSwipableCardStyle = () => {
-    let opacity = this.props.animateCardOpacity ? this.interpolateCardOpacity() : 1;
-    let rotation = this.interpolateRotation();
+    const opacity = this.props.animateCardOpacity ? this.interpolateCardOpacity() : 1;
+    const rotation = this.interpolateRotation();
 
     return [
       styles.card,
@@ -493,8 +493,8 @@ class Swiper extends React.Component {
 
     const swipableCardStyle = this.calculateSwipableCardStyle();
     const firstCardContent = cards[firstCardIndex];
-    let firstCard = this.props.renderCard(firstCardContent);
-    let renderOverlayLabel = this.renderOverlayLabel();
+    const firstCard = this.props.renderCard(firstCardContent);
+    const renderOverlayLabel = this.renderOverlayLabel();
 
     const notInfinite = !this.props.infinite;
     if (notInfinite && this.state.swipedAllCards) {
@@ -518,7 +518,7 @@ class Swiper extends React.Component {
 
     const secondCardZoomStyle = this.calculateSecondCardZoomStyle();
     const secondCardContent = cards[secondCardIndex];
-    let secondCard = renderCard(secondCardContent);
+    const secondCard = renderCard(secondCardContent);
 
     const notInfinite = !this.props.infinite;
     const lastCardOrSwipedAllCards =
@@ -547,13 +547,27 @@ class Swiper extends React.Component {
     );
   };
 
-  renderOverlayLabel = () => this.state.labelType!=='none' ?
+  renderOverlayLabel = () => {
+    const {
+      disableBottomSwipe,
+      disableLeftSwipe,
+      disableRightSwipe,
+      disableTopSwipe
+    } = this.props;
+
+    return this.state.labelType!=='none' ?
+    (!(this.state.labelType==='bottom' && disableBottomSwipe) &&
+    !(this.state.labelType==='left' && disableLeftSwipe) &&
+    !(this.state.labelType==='right' && disableRightSwipe) &&
+    !(this.state.labelType==='top' && disableTopSwipe)) ?
       (<Animated.View style={this.calculateOverlayLabelWrapperStyle()}>
         <Text style={this.calculateOverlayLabelStyle()}>
           {this.props.overlayLabels[this.state.labelType].title}
         </Text>
       </Animated.View>)
-    : null
+      : null
+    : null;
+  }
 }
 
 Swiper.propTypes = {

--- a/Swiper.js
+++ b/Swiper.js
@@ -589,7 +589,7 @@ Swiper.propTypes = {
   backgroundColor: PropTypes.string,
   cardHorizontalMargin: PropTypes.number,
   cardIndex: PropTypes.number,
-  cardStyle: PropTypes.object,
+  cardStyle: PropTypes.oneOfType([PropTypes.number, PropTypes.object]),
   cardVerticalMargin: PropTypes.number,
   cards: PropTypes.array.isRequired,
   childrenOnTop: PropTypes.bool,

--- a/Swiper.js
+++ b/Swiper.js
@@ -306,35 +306,17 @@ class Swiper extends React.Component {
   };
 
   calculateOverlayLabelStyle = () => {
-    let externalStyles = {}, dynamicStyles = {};
+    let externalStyles = styles.overlayLabel, dynamicStyles = {};
     const labelProps = this.props.overlayLabels[this.state.labelType];
-    switch(this.state.labelType) {
-      case 'bottom':
-        externalStyles = styles.overlayLabelBottom;
-      break;
-
-      case 'left':
-        externalStyles = styles.overlayLabelLeft;
-      break;
-
-      case 'right':
-        externalStyles = styles.overlayLabelRight;
-      break;
-
-      case 'top':
-        externalStyles = styles.overlayLabelTop;
-      break;
-
-      default:
-        externalStyles = styles.hideOverlayLabel;
-    }
     if (this.state.labelType!=='none') {
       dynamicStyles = {
         backgroundColor: this.hex2rgba(labelProps.swipeColor, labelProps.backgroundOpacity),
         borderColor: labelProps.swipeColor,
-        color: '#FFF',
+        color: labelProps.fontColor,
         borderWidth: 1
       };
+    } else {
+      externalStyles = styles.hideOverlayLabel;
     }
     return [externalStyles, dynamicStyles];
   }
@@ -667,22 +649,26 @@ Swiper.defaultProps = {
     bottom: {
       title: 'BLEAH',
       swipeColor: '#946C8C',
-      backgroundOpacity: '0.75'
+      backgroundOpacity: '0.75',
+      fontColor: '#FFF'
     },
     left: {
       title: 'NOPE',
       swipeColor: '#4A2359',
-      backgroundOpacity: '0.75'
+      backgroundOpacity: '0.75',
+      fontColor: '#FFF'
     },
     right: {
       title: 'LIKE',
       swipeColor: '#FA9F8C',
-      backgroundOpacity: '0.75'
+      backgroundOpacity: '0.75',
+      fontColor: '#FFF'
     },
     top: {
       title: 'SUPER LIKE',
       swipeColor: '#FFC37B',
-      backgroundOpacity: '0.75'
+      backgroundOpacity: '0.75',
+      fontColor: '#FFF'
     }
   },
   previousCardInitialPositionX: 0,

--- a/Swiper.js
+++ b/Swiper.js
@@ -13,6 +13,18 @@ import styles, { circleSize } from "./styles";
 const { height, width } = Dimensions.get("window");
 
 class Swiper extends React.Component {
+  componentWillReceiveProps(newProps){
+    this.setState({
+      firstCardIndex: 0,
+      cards: newProps.cards,
+      previousCardX: new Animated.Value(newProps.previousCardInitialPositionX),
+      previousCardY: new Animated.Value(newProps.previousCardInitialPositionY),
+      swipedAllCards: false,
+      secondCardIndex: newProps.cards.length === 1 ? 0 : 1,
+      previousCardIndex: newProps.cards.length === 1 ? 0 : newProps.cards.length - 1
+    });
+  }
+
   constructor(props) {
     super(props);
 
@@ -20,14 +32,15 @@ class Swiper extends React.Component {
       pan: new Animated.ValueXY(),
       scale: new Animated.Value(props.secondCardZoom),
       firstCardIndex: props.cardIndex,
-      secondCardIndex: this.calculateSecondCardIndex(props.cardIndex),
-      previousCardIndex: this.calculatePreviousCardIndex(props.cardIndex),
+      cards: props.cards,
       previousCardX: new Animated.Value(props.previousCardInitialPositionX),
       previousCardY: new Animated.Value(props.previousCardInitialPositionY),
       swipedAllCards: false,
       panResponderLocked: false,
       labelType: 'none'
     };
+    this.state.secondCardIndex = this.calculateSecondCardIndex(props.cardIndex);
+    this.state.previousCardIndex = this.calculatePreviousCardIndex(props.cardIndex);
   }
 
   hex2rgba = (hex,opacity  = 1) => {
@@ -39,13 +52,13 @@ class Swiper extends React.Component {
   }
 
   calculateSecondCardIndex = firstCardIndex => {
-    const cardIndexAtLastIndex = firstCardIndex === this.props.cards.length - 1;
+    const cardIndexAtLastIndex = firstCardIndex === this.state.cards.length - 1;
     return cardIndexAtLastIndex ? 0 : firstCardIndex + 1;
   };
 
   calculatePreviousCardIndex = firstCardIndex => {
     const atFirstIndex = firstCardIndex === 0;
-    return atFirstIndex ? this.props.cards.length - 1 : firstCardIndex - 1;
+    return atFirstIndex ? this.state.cards.length - 1 : firstCardIndex - 1;
   };
 
   componentWillMount() {
@@ -249,7 +262,7 @@ class Swiper extends React.Component {
     let newCardIndex = firstCardIndex + 1;
     let swipedAllCards = false;
 
-    if (newCardIndex === this.props.cards.length) {
+    if (newCardIndex === this.state.cards.length) {
       newCardIndex = 0;
       swipedAllCards = true;
     }
@@ -261,7 +274,7 @@ class Swiper extends React.Component {
   decrementCardIndex = cb => {
     const { firstCardIndex } = this.state;
     const newCardIndex = firstCardIndex === 0
-      ? this.props.cards.length - 1
+      ? this.state.cards.length - 1
       : firstCardIndex - 1;
     const swipedAllCards = false;
 
@@ -270,7 +283,7 @@ class Swiper extends React.Component {
   };
 
   jumpToCardIndex = newCardIndex => {
-    if (this.props.cards[newCardIndex]) {
+    if (this.state.cards[newCardIndex]) {
       this.setCardIndex(newCardIndex, false);
     }
   };

--- a/Swiper.js
+++ b/Swiper.js
@@ -30,6 +30,14 @@ class Swiper extends React.Component {
     };
   }
 
+  hex2rgba = (hex,opacity  = 1) => {
+    hex = hex.replace('#','');
+    r = parseInt(hex.substring(0,2), 16);
+    g = parseInt(hex.substring(2,4), 16);
+    b = parseInt(hex.substring(4,6), 16);
+    return `'rgba(${r},${g},${b},${opacity})'`;
+  }
+
   calculateSecondCardIndex = firstCardIndex => {
     const cardIndexAtLastIndex = firstCardIndex === this.props.cards.length - 1;
     return cardIndexAtLastIndex ? 0 : firstCardIndex + 1;
@@ -101,9 +109,6 @@ class Swiper extends React.Component {
     const isSwipingRight = this._animatedValueX > horizontalThreshold;
     const isSwipingTop = this._animatedValueY < -verticalThreshold;
     const isSwipingBottom = this._animatedValueY > verticalThreshold;
-
-    console.log(this._animatedValueX, this._animatedValueY, horizontalThreshold, verticalThreshold);
-
     if (isSwipingRight) {
       this.setState({labelType: 'right'});
     } else if (isSwipingLeft) {
@@ -302,6 +307,7 @@ class Swiper extends React.Component {
 
   calculateOverlayLabelStyle = () => {
     let externalStyles = {}, dynamicStyles = {};
+    const labelProps = this.props.overlayLabels[this.state.labelType];
     switch(this.state.labelType) {
       case 'bottom':
         externalStyles = styles.overlayLabelBottom;
@@ -324,8 +330,8 @@ class Swiper extends React.Component {
     }
     if (this.state.labelType!=='none') {
       dynamicStyles = {
-        backgroundColor: this.props.overlayLabels[this.state.labelType].backgroundColor,
-        borderColor: this.props.overlayLabels[this.state.labelType].borderColor,
+        backgroundColor: this.hex2rgba(labelProps.swipeColor, labelProps.backgroundOpacity),
+        borderColor: labelProps.swipeColor,
         color: '#FFF',
         borderWidth: 1
       };
@@ -660,23 +666,23 @@ Swiper.defaultProps = {
   overlayLabels: {
     bottom: {
       title: 'BLEAH',
-      backgroundColor: 'rgba(148,108,140,0.75)',
-      borderColor: '#946C8C'
+      swipeColor: '#946C8C',
+      backgroundOpacity: '0.75'
     },
     left: {
       title: 'NOPE',
-      backgroundColor: 'rgba(74,35,89,0.75)',
-      borderColor: '#4A2359'
+      swipeColor: '#4A2359',
+      backgroundOpacity: '0.75'
     },
     right: {
       title: 'LIKE',
-      backgroundColor: 'rgba(250,159,140,0.75)',
-      borderColor: '#FA9F8C'
+      swipeColor: '#FA9F8C',
+      backgroundOpacity: '0.75'
     },
     top: {
       title: 'SUPER LIKE',
-      backgroundColor: 'rgba(255,195,123,0.75)',
-      borderColor: '#FFC37B'
+      swipeColor: '#FFC37B',
+      backgroundOpacity: '0.75'
     }
   },
   previousCardInitialPositionX: 0,

--- a/styles.js
+++ b/styles.js
@@ -1,4 +1,4 @@
-import { StyleSheet } from "react-native"
+import { StyleSheet } from "react-native";
 
 const styles = StyleSheet.create({
   card: {
@@ -15,7 +15,25 @@ const styles = StyleSheet.create({
   },
   childrenViewStyle: {
     position: 'absolute'
+  },
+  overlayLabelWrapper: {
+    position: 'absolute',
+    backgroundColor: 'transparent',
+    zIndex: 2,
+    flex: 1,
+    width: '100%',
+    height: '100%'
+  },
+  hideOverlayLabel: {
+    opacity: 0
+  },
+  overlayLabel: {
+    fontSize: 45,
+    fontWeight: 'bold',
+    borderRadius: 10,
+    padding: 10,
+    overflow: 'hidden'
   }
-})
+});
 
-export default styles
+export default styles;


### PR DESCRIPTION
Added swipe labels props and functionality (see screenshots below).

### Important changes:
**animateOpacity** => **animateCardOpacity**
**inputOpacityRangeX** => **inputCardOpacityRangeX**
**outputOpacityRangeX** => **outputCardOpacityRangeX**
**inputOpacityRangeY** => **inputCardOpacityRangeY**
**outputOpacityRangeY** => **outputCardOpacityRangeY**

### New props
- animateOverlayLabelsOpacity
- inputOverlayLabelsOpacityRangeX
- outputOverlayLabelsOpacityRangeX
- inputOverlayLabelsOpacityRangeY
- outputOverlayLabelsOpacityRangeY
- overlayLabels

### Screenshots
**Swipe top**
![swipe-top](https://user-images.githubusercontent.com/864054/27086437-db449b74-505a-11e7-8b3c-e9b5fe579bd5.png)
**Swipe left**
![swipe-left](https://user-images.githubusercontent.com/864054/27086438-db47a6ca-505a-11e7-8aca-59dc142de4ef.png)
**Swipe right**
![swipe-right](https://user-images.githubusercontent.com/864054/27086436-db422060-505a-11e7-85b1-430accded7a5.png)
**Swipe bottom**
![swipe-bottom](https://user-images.githubusercontent.com/864054/27086439-db48b92a-505a-11e7-89ca-b964bf13fd5c.png)