### PR TITLE
onPanResponderTerminate

### DIFF
--- a/Swiper.js
+++ b/Swiper.js
@@ -111,7 +111,8 @@ class Swiper extends React.Component {
       onMoveShouldSetPanResponder: (event, gestureState) => true,
       onPanResponderGrant: this.onPanResponderGrant,
       onPanResponderMove: this.onPanResponderMove,
-      onPanResponderRelease: this.onPanResponderRelease
+      onPanResponderRelease: this.onPanResponderRelease,
+      onPanResponderTerminate: this.onPanResponderRelease
     });
   };
 


### PR DESCRIPTION
When another component has become the responder, we should finish the animation. 
This was causing me a bug. 