### PR TITLE
Fixed hardcoded 0 in componentWillReceiveProps

### DIFF
--- a/Swiper.js
+++ b/Swiper.js
@@ -15,7 +15,7 @@ const LABEL_TYPES = {
 class Swiper extends React.Component {
   componentWillReceiveProps (newProps) {
     this.setState({
-      firstCardIndex: 0,
+      firstCardIndex: newProps.cardIndex || 0,
       cards: newProps.cards,
       previousCardX: new Animated.Value(newProps.previousCardInitialPositionX),
       previousCardY: new Animated.Value(newProps.previousCardInitialPositionY),


### PR DESCRIPTION
Hi,
I had a problem where rerender of the swiper would reset its current card. There seemed to be a hardcoded 0 index in componentWillReceiveProps method.
This seems to fix the problem :). 