### PR TITLE
Update render and remove useless calculations

### DIFF
--- a/Swiper.js
+++ b/Swiper.js
@@ -631,7 +631,7 @@ class Swiper extends React.Component {
         {this.renderChildren()}
         {this.renderFirstCard()}
         {this.props.showSecondCard ? this.renderSecondCard() : null}
-        {this.renderSwipeBackCard()}
+        {this.props.swipeBackCard ? this.renderSwipeBackCard() : null}
       </View>
     )
   }
@@ -796,6 +796,7 @@ Swiper.propTypes = {
   showSecondCard: PropTypes.bool,
   swipeAnimationDuration: PropTypes.number,
   swipeBackAnimationDuration: PropTypes.number,
+  swipeBackCard: PropTypes.bool,
   swipeBackFriction: PropTypes.number,
   verticalSwipe: PropTypes.bool,
   verticalThreshold: PropTypes.number,
@@ -875,6 +876,7 @@ Swiper.defaultProps = {
   showSecondCard: true,
   swipeAnimationDuration: 350,
   swipeBackAnimationDuration: 600,
+  swipeBackCard: false,
   swipeBackFriction: 11,
   verticalSwipe: true,
   verticalThreshold: height / 5,

--- a/Swiper.js
+++ b/Swiper.js
@@ -630,7 +630,7 @@ class Swiper extends React.Component {
       >
         {this.renderChildren()}
         {this.renderFirstCard()}
-        {this.renderSecondCard()}
+        {this.props.showSecondCard ? this.renderSecondCard() : null}
         {this.renderSwipeBackCard()}
       </View>
     )
@@ -679,7 +679,7 @@ class Swiper extends React.Component {
 
   renderSecondCard = () => {
     const { secondCardIndex } = this.state
-    const { cards, renderCard, showSecondCard } = this.props
+    const { cards, renderCard } = this.props
 
     const secondCardZoomStyle = this.calculateSecondCardZoomStyle()
     const secondCardContent = cards[secondCardIndex]
@@ -694,7 +694,7 @@ class Swiper extends React.Component {
 
     return (
       <Animated.View style={secondCardZoomStyle}>
-        {showSecondCard ? secondCard : null}
+        {secondCard}
       </Animated.View>
     )
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-deck-swiper",
-    "version": "1.3.7",
+    "version": "1.3.8",
     "description": "Awesome tinder like card swiper for react-native. Highly Customizable!",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
With this updates:
- the second card is rendered only when the boolean props showSecondCard is "true"
- the swipe back card is rendered only when the boolean props swipeBackCard is "true" (default at "false")