### PR TITLE
[Overlay] added threshold for overlay swiping

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ npm install react-native-deck-swiper --save
 | outputOverlayLabelsOpacityRangeX | array | opacity values for the values in inputOverlayLabelsOpacityRangeX | [1, 0, 0, 0, 1] |
 | inputOverlayLabelsOpacityRangeY | array | pan x overlay labels opacity input range | [-height / 4, -height / 5, 0, height / 5, height / 4] |
 | outputOverlayLabelsOpacityRangeY | array | opacity values for the values in inputOverlayLabelsOpacityRangeY | [1, 0, 0, 0, 1] |
+| overlayOpacityVerticalThreshold | number | vertical threshold for overlay label  | height / 5 |
+| overlayOpacityHorizontalThreshold | number | horizontal threshold for overlay label  | width / 4 |
 
 2 steps of inputOverlayLabelsOpacityRangeX and inputOverlayLabelsOpacityRangeY should match horizontalThreshold and verticalThreshold, respectively.
 

--- a/Swiper.js
+++ b/Swiper.js
@@ -124,11 +124,27 @@ class Swiper extends React.Component {
   }
 
   onPanResponderMove = (event, gestureState) => {
-    const { horizontalThreshold, verticalThreshold } = this.props
-    const isSwipingLeft = this._animatedValueX < -horizontalThreshold
-    const isSwipingRight = this._animatedValueX > horizontalThreshold
-    const isSwipingTop = this._animatedValueY < -verticalThreshold
-    const isSwipingBottom = this._animatedValueY > verticalThreshold
+    let { overlayOpacityHorizontalThreshold, overlayOpacityVerticalThreshold } = this.props
+    if (!overlayOpacityHorizontalThreshold) overlayOpacityHorizontalThreshold = this.props.horizontalThreshold;
+        if (!overlayOpacityVerticalThreshold) overlayOpacityVerticalThreshold = this.props.verticalThreshold;
+
+        let isSwipingLeft,
+            isSwipingRight,
+            isSwipingTop,
+            isSwipingBottom;
+    
+    if (Math.abs(this._animatedValueX) > Math.abs(this._animatedValueY) && Math.abs(this._animatedValueX) > overlayOpacityHorizontalThreshold) {
+        if (this._animatedValueX > 0)
+            isSwipingRight = true;
+        else
+            isSwipingLeft = true;	
+    }
+    else if (Math.abs(this._animatedValueY) > Math.abs(this._animatedValueX) && Math.abs(this._animatedValueY) > overlayOpacityVerticalThreshold) {
+        if (this._animatedValueY > 0)
+            isSwipingBottom = true;
+        else
+            isSwipingTop = true;	
+    }
 
     if (isSwipingRight) {
       this.setState({ labelType: LABEL_TYPES.RIGHT })
@@ -751,6 +767,8 @@ Swiper.propTypes = {
   overlayLabels: PropTypes.object,
   overlayLabelStyle: PropTypes.object,
   overlayLabelWrapperStyle: PropTypes.object,
+  overlayOpacityHorizontalThreshold: PropTypes.number,
+  overlayOpacityVerticalThreshold: PropTypes.number,
   previousCardInitialPositionX: PropTypes.number,
   previousCardInitialPositionY: PropTypes.number,
   renderCard: PropTypes.func.isRequired,
@@ -848,6 +866,8 @@ Swiper.defaultProps = {
     width: '100%',
     height: '100%'
   },
+  overlayOpacityHorizontalThreshold: width / 4,
+  overlayOpacityVerticalThreshold: height / 5,
   previousCardInitialPositionX: 0,
   previousCardInitialPositionY: -height,
   secondCardZoom: 0.97,

--- a/Swiper.js
+++ b/Swiper.js
@@ -125,25 +125,20 @@ class Swiper extends React.Component {
 
   onPanResponderMove = (event, gestureState) => {
     let { overlayOpacityHorizontalThreshold, overlayOpacityVerticalThreshold } = this.props
-    if (!overlayOpacityHorizontalThreshold) overlayOpacityHorizontalThreshold = this.props.horizontalThreshold;
-        if (!overlayOpacityVerticalThreshold) overlayOpacityVerticalThreshold = this.props.verticalThreshold;
+    if (!overlayOpacityHorizontalThreshold) overlayOpacityHorizontalThreshold = this.props.horizontalThreshold
+    if (!overlayOpacityVerticalThreshold) overlayOpacityVerticalThreshold = this.props.verticalThreshold
 
-        let isSwipingLeft,
-            isSwipingRight,
-            isSwipingTop,
-            isSwipingBottom;
-    
+    let isSwipingLeft,
+      isSwipingRight,
+      isSwipingTop,
+      isSwipingBottom
+
     if (Math.abs(this._animatedValueX) > Math.abs(this._animatedValueY) && Math.abs(this._animatedValueX) > overlayOpacityHorizontalThreshold) {
-        if (this._animatedValueX > 0)
-            isSwipingRight = true;
-        else
-            isSwipingLeft = true;	
-    }
-    else if (Math.abs(this._animatedValueY) > Math.abs(this._animatedValueX) && Math.abs(this._animatedValueY) > overlayOpacityVerticalThreshold) {
-        if (this._animatedValueY > 0)
-            isSwipingBottom = true;
-        else
-            isSwipingTop = true;	
+      if (this._animatedValueX > 0) isSwipingRight = true
+      else isSwipingLeft = true
+    } else if (Math.abs(this._animatedValueY) > Math.abs(this._animatedValueX) && Math.abs(this._animatedValueY) > overlayOpacityVerticalThreshold) {
+      if (this._animatedValueY > 0) isSwipingBottom = true
+      else isSwipingTop = true
     }
 
     if (isSwipingRight) {
@@ -711,14 +706,14 @@ class Swiper extends React.Component {
     return (
       <Animated.View style={this.calculateOverlayLabelWrapperStyle()}>
         { !overlayLabels[labelType].element &&
-        <Text style={this.calculateOverlayLabelStyle()}>
-  {overlayLabels[labelType].title}
-			</Text>
-		}
+          <Text style={this.calculateOverlayLabelStyle()}>
+            {overlayLabels[labelType].title}
+          </Text>
+        }
 
         { overlayLabels[labelType].element &&
-			overlayLabels[labelType].element
-		}
+          overlayLabels[labelType].element
+        }
       </Animated.View>
     )
   }


### PR DESCRIPTION
Overlay not render until one of the four sides of the screen width when swiping left or right. The same case for scrolling up and down. I fix this. Conform to ESLint rules.