### PR TITLE
Remove unnecessary index.ios.js file in examples

### DIFF
--- a/Exemples/index.ios.js
+++ b/Exemples/index.ios.js
@@ -1,7 +1,0 @@
-import React, { Component } from 'react'
-import Exemple from './App'
-import {
-  AppRegistry
-} from 'react-native'
-
-AppRegistry.registerComponent('Exemple', () => Exemple)

--- a/Exemples/index.js
+++ b/Exemples/index.js
@@ -1,4 +1,3 @@
-import React, { Component } from 'react'
 import Exemple from './App'
 import {
   AppRegistry


### PR DESCRIPTION
Hi, thanks for sharing the project. Great job!

Initially, I wanted to fix the typo in Exemples, but couldn't find an easy way to go about it, so decided to settle on tiny duplication fix.

I removed `index.os.js` as react-native bundler will pick it up from index.js automatically for both platforms.

Hope this makes it a little better.

Cheers!