### PR TITLE
avoid rerender if props have not changed

### DIFF
--- a/Swiper.js
+++ b/Swiper.js
@@ -36,6 +36,16 @@ class Swiper extends React.Component {
   }
 
   componentWillReceiveProps (newProps) {
+    if (
+      newProps.cardIndex === this.props.cardIndex &&
+      newProps.cards.length === this.props.cards.length &&
+      newProps.previousCardInitialPositionX ===
+      this.props.previousCardInitialPositionX &&
+      newProps.previousCardInitialPositionY ===
+      this.props.previousCardInitialPositionY
+    ) {
+      return;
+    }
     this.setState({
       firstCardIndex: newProps.cardIndex || 0,
       cards: newProps.cards,


### PR DESCRIPTION
Avoid triggering animation if not needed.
Right now anytime componentwillreceiveprops is called an anumation is triggered and the card flash/blink.
This causes a flash if you call setstate inside a onswipe.

The current fix only trigger animation when card deck size has changed, I do not think it's problem but maybe I a missing something.