### PR TITLE
Stack effect feature

### DIFF
--- a/Exemples/App.js
+++ b/Exemples/App.js
@@ -6,7 +6,7 @@ export default class Exemple extends Component {
   constructor (props) {
     super(props)
     this.state = {
-      cards: ['1', '2', '3'],
+      cards: ['HELL', 'FUCKING', 'YESS'],
       swipedAllCards: false,
       swipeDirection: '',
       isSwipingBack: false,
@@ -65,6 +65,8 @@ export default class Exemple extends Component {
           cardVerticalMargin={80}
           renderCard={this.renderCard}
           onSwipedAll={this.onSwipedAllCards}
+          stackSize={3}
+          stackSeparation={15}
           overlayLabels={{
             bottom: {
               title: 'BLEAH',

--- a/README.md
+++ b/README.md
@@ -1,24 +1,27 @@
 ## react-native-deck-swiper
-Fork to add stack effect
+
+[![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/dwyl/esta/issues)
+[![npm version](https://badge.fury.io/js/react-native-deck-swiper.svg)](https://badge.fury.io/js/react-native-deck-swiper)
 
 ## Installation
+
 ```
-npm install gonzaloriestra/react-native-deck-swiper --save
+npm install react-native-deck-swiper --save
 ```
 
 ## Overview
 
-- [x] Rotation animation
-- [x] Opacity animation 
-- [x] Zoom animation
-- [x] Overlay labels
-- [x] Show next card while swiping
-- [x] Swipe event callbacks
-- [x] Trigger swipe animations programmatically
-- [x] Jump to a card index
-- [x] Swipe to the previous card
-- [X] Underlaying cards offset
-- [ ] Swipe back to the previous card with a custom animation
+* [x] Rotation animation
+* [x] Opacity animation
+* [x] Zoom animation
+* [x] Overlay labels
+* [x] Show next card while swiping
+* [x] Swipe event callbacks
+* [x] Trigger swipe animations programmatically
+* [x] Jump to a card index
+* [x] Swipe to the previous card
+* [x] Underlaying cards offset
+* [ ] Swipe back to the previous card with a custom animation
 
 ## Preview
 
@@ -29,83 +32,89 @@ npm install gonzaloriestra/react-native-deck-swiper --save
 
 ### Card props
 
-| Props    | type   | description                                                                                             | required | default                          |
-|:----------|:--------|:---------------------------------------------------------------------------------------------------------|:----------------------------------|:------------|
-| cards    | array | array of data for the cards to be rendered | required |
-| renderCard    | func(cardData) | function to render the card based on the data | required |
-| cardIndex | number | cardIndex to start with | | 0 |
-| infinite | bool | keep swiping indefinitely | | false |
-| horizontalSwipe | bool | enable/disable horizontal swiping | | true |
-| verticalSwipe | bool | enable/disable vertical swiping | | true |
-| showSecondCard | bool | enable/disable second card while swiping | | true |
-| stackSize | number | number of underlaying cards to show (showSecondCard must be enabled)  | | 0 |
+| Props           | type           | description                                                          | required | default |
+| :-------------- | :------------- | :------------------------------------------------------------------- | :------- | :------ |
+| cards           | array          | array of data for the cards to be rendered                           | required |
+| renderCard      | func(cardData) | function to render the card based on the data                        | required |
+| cardIndex       | number         | cardIndex to start with                                              |          | 0       |
+| infinite        | bool           | keep swiping indefinitely                                            |          | false   |
+| horizontalSwipe | bool           | enable/disable horizontal swiping                                    |          | true    |
+| verticalSwipe   | bool           | enable/disable vertical swiping                                      |          | true    |
+| showSecondCard  | bool           | enable/disable second card while swiping                             |          | true    |
+| stackSize       | number         | number of underlaying cards to show (showSecondCard must be enabled) |          | 0       |
 
 ### Event callbacks
-| Props    | type   | description                                                                                             | default                          |
-|:----------|:--------|:---------------------------------------------------------------------------------------------------------|:----------------------------------|
-| onSwipedAll| func | function to be called when all cards have been swiped | | () => {} |
-| onSwiped | func | function to be called when a card is swiped. it receives the swiped card index | | (cardIndex) => {} |
-| onSwipedLeft | func | function to be called when a card is swiped left. it receives the swiped card index | | (cardIndex) => {} |
-| onSwipedRight | func | function to be called when a card is swiped right. it receives the swiped card index |  | (cardIndex) => {} |
-| onSwipedTop | func | function to be called when a card is swiped top. it receives the swiped card index | | (cardIndex) => {} |
-| onSwipedBottom | func | function to be called when a card is swiped bottom. it receives the swiped card index | | (cardIndex) => {} |
-| onTapCard | func | function to be called when tapping a card. it receives the tapped card index | | (cardIndex) => {} |
-| onTapCardDeadZone | number | maximum amount of movement before a tap is no longer recognized as a tap | 5 |
+
+| Props             | type   | description                                                                           | default |
+| :---------------- | :----- | :------------------------------------------------------------------------------------ | :------ |
+| onSwipedAll       | func   | function to be called when all cards have been swiped                                 |         | () => {} |
+| onSwiped          | func   | function to be called when a card is swiped. it receives the swiped card index        |         | (cardIndex) => {} |
+| onSwipedAborted   | func   | function to be called when a card is released before reaching the threshold           |         | () => {} |
+| onSwipedLeft      | func   | function to be called when a card is swiped left. it receives the swiped card index   |         | (cardIndex) => {} |
+| onSwipedRight     | func   | function to be called when a card is swiped right. it receives the swiped card index  |         | (cardIndex) => {} |
+| onSwipedTop       | func   | function to be called when a card is swiped top. it receives the swiped card index    |         | (cardIndex) => {} |
+| onSwipedBottom    | func   | function to be called when a card is swiped bottom. it receives the swiped card index |         | (cardIndex) => {} |
+| onSwiping         | func   | function to be called when a card is being moved. it receives X and Y positions       |         | (x, y) => {} |
+| onTapCard         | func   | function to be called when tapping a card. it receives the tapped card index          |         | (cardIndex) => {} |
+| onTapCardDeadZone | number | maximum amount of movement before a tap is no longer recognized as a tap              | 5       |
 
 ### Swipe animation props
 
-| Props    | type   | description                                                                                             | default                          |
-|:----------|:--------|:---------------------------------------------------------------------------------------------------------|:----------------------------------|
-| verticalThreshold | number | vertical swipe threshold  | height / 5 |
-| horizontalThreshold | number | horizontal swipe threshold  | width / 4 |
-| swipeAnimationDuration | number | duration of the swipe animation | 350 |
-| disableBottomSwipe | bool | disable bottom swipe | false |
-| disableLeftSwipe | bool | disable left swipe | false |
-| disableRightSwipe | bool | disable right swipe | false |
-| disableTopSwipe | bool | disable top swipe | false |
+| Props                  | type   | description                     | default    |
+| :--------------------- | :----- | :------------------------------ | :--------- |
+| verticalThreshold      | number | vertical swipe threshold        | height / 5 |
+| horizontalThreshold    | number | horizontal swipe threshold      | width / 4  |
+| swipeAnimationDuration | number | duration of the swipe animation | 350        |
+| disableBottomSwipe     | bool   | disable bottom swipe            | false      |
+| disableLeftSwipe       | bool   | disable left swipe              | false      |
+| disableRightSwipe      | bool   | disable right swipe             | false      |
+| disableTopSwipe        | bool   | disable top swipe               | false      |
 
 ### Stack props
 
-| Props    | type   | description                                                                                             | default                          |
-|:----------|:--------|:---------------------------------------------------------------------------------------------------------|:----------------------------------|
-| stackSeparation | number | vertical separation between underlaying cards | 10 |
-| stackScale | number | percentage to reduce the size of each underlaying card | 3 |
-| stackAnimationFriction | number | spring animation friction (bounciness) | 7 |
-| stackAnimationTension | number | spring animation tension (speed) | 40 |
+| Props                  | type   | description                                            | default |
+| :--------------------- | :----- | :----------------------------------------------------- | :------ |
+| stackSeparation        | number | vertical separation between underlaying cards          | 10      |
+| stackScale             | number | percentage to reduce the size of each underlaying card | 3       |
+| stackAnimationFriction | number | spring animation friction (bounciness)                 | 7       |
+| stackAnimationTension  | number | spring animation tension (speed)                       | 40      |
 
 ### Rotation animation props
 
-| Props    | type   | description                                                                                             |  default                          |
-|:----------|:--------|:---------------------------------------------------------------------------------------------------------|:----------------------------------|
-| inputRotationRange | array | x values range for the rotation output | [-width / 2, 0, width / 2] |
-| outputRotationRange | array | rotation values for the x values in inputRotationRange |  ["-10deg", "0deg", "10deg"] |
+| Props               | type  | description                                            | default                     |
+| :------------------ | :---- | :----------------------------------------------------- | :-------------------------- |
+| inputRotationRange  | array | x values range for the rotation output                 | [-width / 2, 0, width / 2]  |
+| outputRotationRange | array | rotation values for the x values in inputRotationRange | ["-10deg", "0deg", "10deg"] |
 
 ### Opacity animation props
-| Props    | type   | description                                                                                             | default                          |
-|:----------|:--------|:---------------------------------------------------------------------------------------------------------|:----------------------------------|
-| animateCardOpacity| bool | animate card opacity | false |
-| inputCardOpacityRangeX | array | pan x card opacity input range | [-width / 2, -width / 3, 0, width / 3, width / 2] |
-| outputCardOpacityRangeX | array | opacity values for the values in inputCardOpacityRangeX | [0.8, 1, 1, 1, 0.8] |
-| inputCardOpacityRangeY | array | pan y card opacity input range | [-height / 2, -height / 3, 0, height / 3, height / 2]
-| outputCardOpacityRangeY | array | opacity values for the values in inputCardOpacityRangeY | [0.8, 1, 1, 1, 0.8] |
-| animateOverlayLabelsOpacity| bool | animate card overlay labels opacity | false |
-| inputOverlayLabelsOpacityRangeX | array | pan x overlay labels opacity input range | [-width / 3, -width / 4, 0, width / 4, width / 3] |
-| outputOverlayLabelsOpacityRangeX | array | opacity values for the values in inputOverlayLabelsOpacityRangeX | [1, 0, 0, 0, 1] |
-| inputOverlayLabelsOpacityRangeY | array | pan x overlay labels opacity input range | [-height / 4, -height / 5, 0, height / 5, height / 4] |
-| outputOverlayLabelsOpacityRangeY | array | opacity values for the values in inputOverlayLabelsOpacityRangeY | [1, 0, 0, 0, 1] |
-| overlayOpacityVerticalThreshold | number | vertical threshold for overlay label  | height / 5 |
-| overlayOpacityHorizontalThreshold | number | horizontal threshold for overlay label  | width / 4 |
+
+| Props                             | type   | description                                                      | default                                               |
+| :-------------------------------- | :----- | :--------------------------------------------------------------- | :---------------------------------------------------- |
+| animateCardOpacity                | bool   | animate card opacity                                             | false                                                 |
+| inputCardOpacityRangeX            | array  | pan x card opacity input range                                   | [-width / 2, -width / 3, 0, width / 3, width / 2]     |
+| outputCardOpacityRangeX           | array  | opacity values for the values in inputCardOpacityRangeX          | [0.8, 1, 1, 1, 0.8]                                   |
+| inputCardOpacityRangeY            | array  | pan y card opacity input range                                   | [-height / 2, -height / 3, 0, height / 3, height / 2] |
+| outputCardOpacityRangeY           | array  | opacity values for the values in inputCardOpacityRangeY          | [0.8, 1, 1, 1, 0.8]                                   |
+| animateOverlayLabelsOpacity       | bool   | animate card overlay labels opacity                              | false                                                 |
+| inputOverlayLabelsOpacityRangeX   | array  | pan x overlay labels opacity input range                         | [-width / 3, -width / 4, 0, width / 4, width / 3]     |
+| outputOverlayLabelsOpacityRangeX  | array  | opacity values for the values in inputOverlayLabelsOpacityRangeX | [1, 0, 0, 0, 1]                                       |
+| inputOverlayLabelsOpacityRangeY   | array  | pan x overlay labels opacity input range                         | [-height / 4, -height / 5, 0, height / 5, height / 4] |
+| outputOverlayLabelsOpacityRangeY  | array  | opacity values for the values in inputOverlayLabelsOpacityRangeY | [1, 0, 0, 0, 1]                                       |
+| overlayOpacityVerticalThreshold   | number | vertical threshold for overlay label                             | height / 5                                            |
+| overlayOpacityHorizontalThreshold | number | horizontal threshold for overlay label                           | width / 4                                             |
 
 2 steps of inputOverlayLabelsOpacityRangeX and inputOverlayLabelsOpacityRangeY should match horizontalThreshold and verticalThreshold, respectively.
 
 ### Swipe overlay labels
-| Props    | type   | description                                                                                             | default                          |
-|:----------|:--------|:---------------------------------------------------------------------------------------------------------|:----------------------------------|
-| overlayLabels| object | swipe labels title and style | null, see below for format |
-| overlayLabelStyle | object | swipe labels style | null, see below for format |
-| overlayLabelWrapperStyle | object   | overlay label wrapper style | see below for default | 
+
+| Props                    | type   | description                  | default                    |
+| :----------------------- | :----- | :--------------------------- | :------------------------- |
+| overlayLabels            | object | swipe labels title and style | null, see below for format |
+| overlayLabelStyle        | object | swipe labels style           | null, see below for format |
+| overlayLabelWrapperStyle | object | overlay label wrapper style  | see below for default      |
 
 ### overlayLabelStyle
+
 ```javascript
 {
   fontSize: 45,
@@ -116,7 +125,8 @@ npm install gonzaloriestra/react-native-deck-swiper --save
 }
 ```
 
-### overlayLabelWrapperStyle default props: 
+### overlayLabelWrapperStyle default props:
+
 ```javascript
 {
   position: 'absolute',
@@ -125,10 +135,10 @@ npm install gonzaloriestra/react-native-deck-swiper --save
   flex: 1,
   width: '100%',
   height: '100%'
-} 
+}
 ```
 
-### overlayLabels default props : 
+### overlayLabels default props :
 
 ```javascript
 {
@@ -211,40 +221,38 @@ npm install gonzaloriestra/react-native-deck-swiper --save
 
 Make sure you set showSecondCard={false} for smoother and proper transitions while going back to previous card.
 
-
-| Props    | type   | description                                                                                             | default                          |
-|:----------|:--------|:---------------------------------------------------------------------------------------------------------|:----------------------------------|
-|goBackToPreviousCardOnSwipeLeft | bool | previous card is rendered on left swipe | false 
-|goBackToPreviousCardOnSwipeRight| bool | previous card is rendered on right swipe | false 
-|goBackToPreviousCardOnSwipeTop| bool | previous card is rendered on top swipe | false
-|goBackToPreviousCardOnSwipeBottom | bool |previous card is rendered on bottom swipe  | false
+| Props                             | type | description                               | default |
+| :-------------------------------- | :--- | :---------------------------------------- | :------ |
+| goBackToPreviousCardOnSwipeLeft   | bool | previous card is rendered on left swipe   | false   |
+| goBackToPreviousCardOnSwipeRight  | bool | previous card is rendered on right swipe  | false   |
+| goBackToPreviousCardOnSwipeTop    | bool | previous card is rendered on top swipe    | false   |
+| goBackToPreviousCardOnSwipeBottom | bool | previous card is rendered on bottom swipe | false   |
 
 ### Style props
 
-| Props    | type   | description                                                                                             | default                          |
-|:----------|:--------|:---------------------------------------------------------------------------------------------------------|:----------------------------------|
-| backgroundColor | string | background color for the view containing the cards | '#4FD0E9' |
-| marginTop | number | marginTop for the swiper container | 0 |
-| marginBottom | number | marginBottom for the swiper container | 0 |
-| cardVerticalMargin | number | card vertical margin | 60 |
-| cardHorizontalMargin | number | card horizontal margin | 20 |
-| childrenOnTop | bool | render children on top or not | false |
-| cardStyle | node | override swipable card style | {} |
+| Props                | type   | description                                        | default   |
+| :------------------- | :----- | :------------------------------------------------- | :-------- |
+| backgroundColor      | string | background color for the view containing the cards | '#4FD0E9' |
+| marginTop            | number | marginTop for the swiper container                 | 0         |
+| marginBottom         | number | marginBottom for the swiper container              | 0         |
+| cardVerticalMargin   | number | card vertical margin                               | 60        |
+| cardHorizontalMargin | number | card horizontal margin                             | 20        |
+| childrenOnTop        | bool   | render children on top or not                      | false     |
+| cardStyle            | node   | override swipable card style                       | {}        |
 
 ### Methods
 
 To trigger imperative animations, you can use a reference to the Swiper component.
 
-| Props    | arguments   | description                                                                                             |
-|:----------|:--------|:---------------------------------------------------------------------------------------------------------|
-| swipeLeft | mustDecrementCardIndex = false | swipe left to the next card |
-| swipeRight | mustDecrementCardIndex = false  | swipe right to the next card |
-| swipeTop | mustDecrementCardIndex = false | swipe top to the next card |
-| swipeBottom | mustDecrementCardIndex = false  | swipe bottom to the next card |
-| jumpToCardIndex | cardIndex | set the current card index |
+| Props           | arguments                      | description                   |
+| :-------------- | :----------------------------- | :---------------------------- |
+| swipeLeft       | mustDecrementCardIndex = false | swipe left to the next card   |
+| swipeRight      | mustDecrementCardIndex = false | swipe right to the next card  |
+| swipeTop        | mustDecrementCardIndex = false | swipe top to the next card    |
+| swipeBottom     | mustDecrementCardIndex = false | swipe bottom to the next card |
+| jumpToCardIndex | cardIndex                      | set the current card index    |
 
 ## Usage example
-
 
 ```javascript
 render () {
@@ -272,29 +280,29 @@ render () {
     </View>
 }
 ```
+
 Demo inside the [Exemples Folder](https://github.com/alexbrillant/react-native-deck-swiper/tree/master/Exemples)
 
 ## Stylesheet example
 
 ```javascript
-
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#F5FCFF'
+    backgroundColor: "#F5FCFF"
   },
   card: {
     flex: 1,
     borderRadius: 4,
     borderWidth: 2,
-    borderColor: '#E8E8E8',
-    justifyContent: 'center',
-    backgroundColor: 'white',
+    borderColor: "#E8E8E8",
+    justifyContent: "center",
+    backgroundColor: "white"
   },
   text: {
-    textAlign: 'center',
+    textAlign: "center",
     fontSize: 50,
-    backgroundColor: 'transparent'
+    backgroundColor: "transparent"
   }
-})
+});
 ```

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ## react-native-deck-swiper
-[![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/dwyl/esta/issues)
-[![npm version](https://badge.fury.io/js/react-native-deck-swiper.svg)](https://badge.fury.io/js/react-native-deck-swiper)
+Fork to add stack effect
+
 ## Installation
 ```
-npm install react-native-deck-swiper --save
+npm install gonzaloriestra/react-native-deck-swiper --save
 ```
 
 ## Overview
@@ -17,8 +17,8 @@ npm install react-native-deck-swiper --save
 - [x] Trigger swipe animations programmatically
 - [x] Jump to a card index
 - [x] Swipe to the previous card
+- [X] Underlaying cards offset
 - [ ] Swipe back to the previous card with a custom animation
-- [ ] Underlaying cards offset
 
 ## Preview
 
@@ -38,6 +38,7 @@ npm install react-native-deck-swiper --save
 | horizontalSwipe | bool | enable/disable horizontal swiping | | true |
 | verticalSwipe | bool | enable/disable vertical swiping | | true |
 | showSecondCard | bool | enable/disable second card while swiping | | true |
+| stackSize | number | number of underlaying cards to show (showSecondCard must be enabled)  | | 0 |
 
 ### Event callbacks
 | Props    | type   | description                                                                                             | default                          |
@@ -63,13 +64,14 @@ npm install react-native-deck-swiper --save
 | disableRightSwipe | bool | disable right swipe | false |
 | disableTopSwipe | bool | disable top swipe | false |
 
-### Zoom animation props
+### Stack props
 
 | Props    | type   | description                                                                                             | default                          |
 |:----------|:--------|:---------------------------------------------------------------------------------------------------------|:----------------------------------|
-| secondCardZoom | number | second card zoom | 0.97 |
-| zoomAnimationDuration | number | duration of the zoom animation | 100 |
-| zoomFriction | number | zoom spring animation friction | 7 |
+| stackSeparation | number | vertical separation between underlaying cards | 10 |
+| stackScale | number | percentage to reduce the size of each underlaying card | 3 |
+| stackAnimationFriction | number | spring animation friction (bounciness) | 7 |
+| stackAnimationTension | number | spring animation tension (speed) | 40 |
 
 ### Rotation animation props
 
@@ -259,7 +261,8 @@ render () {
             onSwiped={(cardIndex) => {console.log(cardIndex)}}
             onSwipedAll={() => {console.log('onSwipedAll')}}
             cardIndex={0}
-            backgroundColor={'#4FD0E9'}>
+            backgroundColor={'#4FD0E9'}
+            stackSize= {3}>
             <Button
                 onPress={() => {console.log('oulala')}}
                 title="Press me">
@@ -295,6 +298,3 @@ const styles = StyleSheet.create({
   }
 })
 ```
-## Todo(contributions are welcome)
-
-Underlaying card offset to achieve a stack effect

--- a/Swiper.js
+++ b/Swiper.js
@@ -500,7 +500,6 @@ class Swiper extends Component {
 
   resetPanAndScale = () => {
     this.state.pan.setValue({ x: 0, y: 0 })
-    this.state.scale.setValue(this.props.secondCardZoom)
 
     this.state.previousCardX.setValue(this.props.previousCardInitialPositionX)
     this.state.previousCardY.setValue(this.props.previousCardInitialPositionY)

--- a/Swiper.js
+++ b/Swiper.js
@@ -131,6 +131,8 @@ class Swiper extends Component {
   }
 
   onPanResponderMove = (event, gestureState) => {
+    this.props.onSwiping(this._animatedValueX, this._animatedValueY);
+
     let { overlayOpacityHorizontalThreshold, overlayOpacityVerticalThreshold } = this.props
     if (!overlayOpacityHorizontalThreshold) {
       overlayOpacityHorizontalThreshold = this.props.horizontalThreshold
@@ -331,6 +333,8 @@ class Swiper extends Component {
       x: 0,
       y: 0
     })
+
+    this.props.onSwipedAborted();
   }
 
   swipeBack = cb => {
@@ -792,11 +796,13 @@ Swiper.propTypes = {
   marginBottom: PropTypes.number,
   marginTop: PropTypes.number,
   onSwiped: PropTypes.func,
+  onSwipedAborted: PropTypes.func,
   onSwipedAll: PropTypes.func,
   onSwipedBottom: PropTypes.func,
   onSwipedLeft: PropTypes.func,
   onSwipedRight: PropTypes.func,
   onSwipedTop: PropTypes.func,
+  onSwiping: PropTypes.func,
   onTapCard: PropTypes.func,
   onTapCardDeadZone: PropTypes.number,
   outputCardOpacityRangeX: PropTypes.array,

--- a/Swiper.js
+++ b/Swiper.js
@@ -21,7 +21,6 @@ class Swiper extends Component {
     this.state = {
       ...this.calculateCardIndexes(props.cardIndex, props.cards),
       pan: new Animated.ValueXY(),
-      scale: new Animated.Value(props.secondCardZoom),
       cards: props.cards,
       previousCardX: new Animated.Value(props.previousCardInitialPositionX),
       previousCardY: new Animated.Value(props.previousCardInitialPositionY),
@@ -548,16 +547,6 @@ class Swiper extends Component {
     ]
   }
 
-  calculateSecondCardZoomStyle = () => [
-    styles.card,
-    this.cardStyle,
-    {
-      zIndex: 1,
-      transform: [{ scale: this.state.scale }]
-    },
-    this.customCardStyle
-  ]
-
   calculateStackCardZoomStyle = (index) => [
     styles.card,
     this.cardStyle,
@@ -641,7 +630,7 @@ class Swiper extends Component {
       >
         {this.renderChildren()}
         {this.renderFirstCard()}
-        {this.renderStack()}
+        {this.props.showSecondCard ? this.renderStack() : null} 
         {this.props.swipeBackCard ? this.renderSwipeBackCard() : null}
       </View>
     )
@@ -684,29 +673,6 @@ class Swiper extends Component {
       >
         {renderOverlayLabel}
         {firstCard}
-      </Animated.View>
-    )
-  }
-
-  renderSecondCard = () => {
-    const { secondCardIndex } = this.state
-    const { cards, renderCard } = this.props
-
-    const secondCardZoomStyle = this.calculateSecondCardZoomStyle()
-    const secondCardContent = cards[secondCardIndex]
-    const secondCard = renderCard(secondCardContent)
-
-    const notInfinite = !this.props.infinite
-    const lastCardOrSwipedAllCards =
-      secondCardIndex === 0 || this.state.swipedAllCards
-    if (notInfinite && lastCardOrSwipedAllCards) {
-      return <Animated.View key={secondCardIndex} />
-    }
-
-    return (
-      <Animated.View key={secondCardIndex} style={secondCardZoomStyle}>
-        {null}
-        {secondCard}
       </Animated.View>
     )
   }
@@ -966,8 +932,8 @@ Swiper.defaultProps = {
   goBackToPreviousCardOnSwipeTop: false,
   goBackToPreviousCardOnSwipeBottom: false,
   stackSeparation: 10,
-  stackScale: 5,
-  stackSize: 2,
+  stackScale: 3,
+  stackSize: 0,
   stackAnimationFriction: 7,
   stackAnimationTension: 40
 }

--- a/Swiper.js
+++ b/Swiper.js
@@ -875,6 +875,12 @@ Swiper.defaultProps = {
   inputRotationRange: [-width / 2, 0, width / 2],
   marginBottom: 0,
   marginTop: 0,
+  onSwiping: () => {
+    console.log('swiped')
+  },
+  onSwipedAborted: () => {
+    console.log('onSwipeAborted')
+  },
   onSwiped: cardIndex => {
     console.log(cardIndex)
   },

--- a/Swiper.js
+++ b/Swiper.js
@@ -836,8 +836,8 @@ Swiper.propTypes = {
   stackSeparation: PropTypes.number,
   stackScale: PropTypes.number,
   stackSize: PropTypes.number,
-  stackAnimationFriction: 7,
-  stackAnimationTension: 40  
+  stackAnimationFriction: PropTypes.number,
+  stackAnimationTension: PropTypes.number  
 }
 
 Swiper.defaultProps = {


### PR DESCRIPTION
I added a stack effect to the cards, keeping backwards compatibility (not shown by default), and customizable with several parameters: cards count, separation, zoom, animation speed...

I also added a couple of new events: `onSwipedAborted` and `onSwiping` (not very related, maybe it should be another PR, sorry).

I couldn't try it with your examples, but here you can see an example:
https://photos.app.goo.gl/STyNQXI95fKuiQT93