### PR TITLE
Add Next Card offset props

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install react-native-deck-swiper --save
 - [x] Jump to a card index
 - [x] Swipe to the previous card
 - [ ] Swipe back to the previous card with a custom animation
-- [ ] Underlaying cards offset
+- [x] Underlaying cards offset
 
 ## Preview
 
@@ -228,6 +228,8 @@ Make sure you set showSecondCard={false} for smoother and proper transitions whi
 | cardHorizontalMargin | number | card horizontal margin | 20 |
 | childrenOnTop | bool | render children on top or not | false |
 | cardStyle | node | override swipable card style | {} |
+| nextCardYOffset | number | Y offset for the card rendered beneath the top card | 0
+| nextCardXOffset | number | X offset for the card rendered beneath the top card | 0
 
 ### Methods
 

--- a/Swiper.js
+++ b/Swiper.js
@@ -28,7 +28,9 @@ class Swiper extends Component {
       swipedAllCards: false,
       panResponderLocked: false,
       labelType: LABEL_TYPES.NONE,
-      slideGesture: false
+      slideGesture: false,
+      nextCardYOffset: new Animated.Value(props.nextCardYOffset),
+      nextCardXOffset: new Animated.Value(props.nextCardXOffset)
     }
   }
 
@@ -411,6 +413,16 @@ class Swiper extends Component {
       friction: this.props.zoomFriction,
       duration: this.props.zoomAnimationDuration
     }).start()
+    Animated.spring(this.state.nextCardYOffset, {
+      toValue: 0,
+      friction: this.props.zoomFriction,
+      duration: this.props.zoomAnimationDuration
+    }).start()
+    Animated.spring(this.state.nextCardXOffset, {
+      toValue: 0,
+      friction: this.props.zoomFriction,
+      duration: this.props.zoomAnimationDuration
+    }).start()
   }
 
   incrementCardIndex = onSwiped => {
@@ -470,6 +482,8 @@ class Swiper extends Component {
   resetPanAndScale = () => {
     this.state.pan.setValue({ x: 0, y: 0 })
     this.state.scale.setValue(this.props.secondCardZoom)
+    this.state.nextCardYOffset.setValue(this.props.nextCardYOffset)
+    this.state.nextCardXOffset.setValue(this.props.nextCardXOffset)
 
     this.state.previousCardX.setValue(this.props.previousCardInitialPositionX)
     this.state.previousCardY.setValue(this.props.previousCardInitialPositionY)
@@ -521,7 +535,11 @@ class Swiper extends Component {
     this.cardStyle,
     {
       zIndex: 1,
-      transform: [{ scale: this.state.scale }]
+      transform: [
+        { scale: this.state.scale },
+        { translateY: this.state.nextCardYOffset },
+        { translateX: this.state.nextCardXOffset }
+      ]
     },
     this.customCardStyle
   ]
@@ -753,6 +771,8 @@ Swiper.propTypes = {
   inputRotationRange: PropTypes.array,
   marginBottom: PropTypes.number,
   marginTop: PropTypes.number,
+  nextCardYOffset: PropTypes.number,
+  nextCardXOffset: PropTypes.number,
   onSwiped: PropTypes.func,
   onSwipedAll: PropTypes.func,
   onSwipedBottom: PropTypes.func,
@@ -826,6 +846,8 @@ Swiper.defaultProps = {
   inputRotationRange: [-width / 2, 0, width / 2],
   marginBottom: 0,
   marginTop: 0,
+  nextCardYOffset: 0,
+  nextCardXOffset: 0,
   onSwiped: cardIndex => {
     console.log(cardIndex)
   },


### PR DESCRIPTION
Added 2 props:
- nextCardYOffset
- nextCardXOffset

These props give an offset to the car rendered underneath the top card.

Here is what they look like in action: 

### Y offset
![yoffset](https://user-images.githubusercontent.com/10929131/37470090-bb4d98c2-2834-11e8-9b8a-8cf20494c450.gif)

### Y and X offset
![yandxoffset](https://user-images.githubusercontent.com/10929131/37470092-be7b570a-2834-11e8-89e1-0936396b987d.gif)

