### PR TITLE
Don't block touch events on the Swiper when childrenOnTop

### DIFF
--- a/Swiper.js
+++ b/Swiper.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { PanResponder, Text, View, Dimensions, Animated } from 'react-native'
 import PropTypes from 'prop-types'
-import _ from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import styles from './styles'
 
@@ -43,7 +43,7 @@ class Swiper extends Component {
   }
 
   componentWillReceiveProps (newProps) {
-    if(!_.isEqual(this.props.cards, newProps.cards) || this.props.cardIndex !== newProps.cardIndex) {
+    if(!isEqual(this.props.cards, newProps.cards) || this.props.cardIndex !== newProps.cardIndex) {
       this.setState({
         ...this.calculateCardIndexes(newProps.cardIndex, newProps.cards),
         cards: newProps.cards,

--- a/Swiper.js
+++ b/Swiper.js
@@ -648,7 +648,7 @@ class Swiper extends Component {
     }
 
     return (
-      <View style={[styles.childrenViewStyle, { zIndex: zIndex }]}>
+      <View pointerEvents="box-none" style={[styles.childrenViewStyle, { zIndex: zIndex }]}>
         {children}
       </View>
     )


### PR DESCRIPTION
https://facebook.github.io/react-native/docs/view.html#pointerevents

When childrenOnTop is true, a View is rendered that covers the entire Swiper and swallows all touch events rendering it unusable. This prevents that view from swallowing touch events, but still allows touch events on the actual children, so you can still have a button as a child for example