### PR TITLE
Dont block touch events when childrenOnTop

### DIFF
--- a/Swiper.js
+++ b/Swiper.js
@@ -648,7 +648,7 @@ class Swiper extends Component {
     }
 
     return (
-      <View style={[styles.childrenViewStyle, { zIndex: zIndex }]}>
+      <View pointerEvents="box-none" style={[styles.childrenViewStyle, { zIndex: zIndex }]}>
         {children}
       </View>
     )


### PR DESCRIPTION
https://facebook.github.io/react-native/docs/view.html#pointerevents

When `childrenOnTop` is `true`, a `View` is rendered that covers the entire `Swiper` and swallows all touch events rendering it unusable. This prevents that view from swallowing touch events, but still allows touch events on the actual children, so you can still have a button as a child for example