### PR TITLE
Fix stackPosition${index} and stackScale${index} animated values when changing deck cards

### DIFF
--- a/Exemples/package.json
+++ b/Exemples/package.json
@@ -11,7 +11,7 @@
         "prop-types": "^15.5.10",
         "react": "^16.2.0",
         "react-native": "^0.49.5",
-        "react-native-deck-swiper": "^1.5.9"
+        "react-native-deck-swiper": "^1.5.11"
     },
     "devDependencies": {
         "babel-jest": "19.0.0",

--- a/Swiper.js
+++ b/Swiper.js
@@ -27,10 +27,9 @@ class Swiper extends Component {
       swipedAllCards: false,
       panResponderLocked: false,
       labelType: LABEL_TYPES.NONE,
-      slideGesture: false
+      slideGesture: false,
+      ...this.rebuildStackAnimatedValues(props.cards)
     }
-
-    this.rebuildStackAnimatedValues()
   }
 
   shouldComponentUpdate = (nextProps, nextState) => {
@@ -48,13 +47,16 @@ class Swiper extends Component {
     return propsChanged || stateChanged
   }
 
-  rebuildStackAnimatedValues = () => {
-    this.state.cards.forEach((card, index) => {
-      const factor = index < this.props.stackSize ? index : this.props.stackSize
+  rebuildStackAnimatedValues = (cards) => {
+    const stackPositionsAndScales = {}
 
-      this.state[`stackPosition${index}`] = new Animated.Value(this.props.stackSeparation * factor)
-      this.state[`stackScale${index}`] = new Animated.Value((100 - this.props.stackScale * factor) * 0.01)
+    cards.forEach((card, index) => {
+      const factor = index < this.props.stackSize ? index : this.props.stackSize
+      stackPositionsAndScales[`stackPosition${index}`] = new Animated.Value(this.props.stackSeparation * factor)
+      stackPositionsAndScales[`stackScale${index}`] = new Animated.Value((100 - this.props.stackScale * factor) * 0.01)
     })
+
+    return stackPositionsAndScales
   }
 
   componentWillReceiveProps = (newProps) => {
@@ -65,9 +67,8 @@ class Swiper extends Component {
       previousCardY: new Animated.Value(newProps.previousCardInitialPositionY),
       swipedAllCards: false,
       panResponderLocked: newProps.cards && newProps.cards.length === 0,
-      slideGesture: false
-    }, () => {
-      this.rebuildStackAnimatedValues()
+      slideGesture: false,
+      ...this.rebuildStackAnimatedValues(newProps.cards)
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-deck-swiper",
-    "version": "1.5.9",
+    "version": "1.5.11",
     "description": "Awesome tinder like card swiper for react-native. Highly Customizable!",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
TypeError: Cannot read property 'getValue' of undefined #151
Fix stackPosition${index} and stackScale${index} animated values out of bounds when randomly adding cards into deck or shuffling deck