### PR TITLE
Add cardIndex in renderCard

### DIFF
--- a/Exemples/package.json
+++ b/Exemples/package.json
@@ -11,7 +11,7 @@
         "prop-types": "^15.5.10",
         "react": "^16.2.0",
         "react-native": "^0.49.5",
-        "react-native-deck-swiper": "^1.5.11"
+        "react-native-deck-swiper": "^1.5.12"
     },
     "devDependencies": {
         "babel-jest": "19.0.0",

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ npm install react-native-deck-swiper --save
 | Props           | type           | description                                                          | required | default |
 | :-------------- | :------------- | :------------------------------------------------------------------- | :------- | :------ |
 | cards           | array          | array of data for the cards to be rendered                           | required |
-| renderCard      | func(cardData) | function to render the card based on the data                        | required |
+| renderCard      | func(cardData, cardIndex) | function to render the card based on the data                        | required |
 | keyExtractor    | func(cardData) | function to get the card's react key                                 |          | null    |
 | cardIndex       | number         | cardIndex to start with                                              |          | 0       |
 | infinite        | bool           | keep swiping indefinitely                                            |          | false   |

--- a/Swiper.js
+++ b/Swiper.js
@@ -674,7 +674,7 @@ class Swiper extends Component {
   pushCardToStack (renderedCards, index, key, firstCard) {
     const { cards } = this.props
     const stackCardZoomStyle = this.calculateStackCardZoomStyle(index)
-    const stackCard = this.props.renderCard(cards[index])
+    const stackCard = this.props.renderCard(cards[index], index)
     const swipableCardStyle = this.calculateSwipableCardStyle()
     const renderOverlayLabel = this.renderOverlayLabel()
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-deck-swiper",
-    "version": "1.5.11",
+    "version": "1.5.12",
     "description": "Awesome tinder like card swiper for react-native. Highly Customizable!",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
### Use case

If you want to implement a simple swiper where you display "1/5, 2/5, 3/5" etc… It would be super useful to have the index in the `renderCard` function, as the `map` function does in `lodash` for example.

If cards are simple strings you can use `findIndex` but if they are a complex object, using `findIndex` could affect performances.

### Usage

```jsx
const CARDS = ['Test', 'lala', 'toto']

…

const CustomCard = ({ card, index }) => <Text>{`Card ${index}`: ${card}</Text>

<Swiper
  …
  renderCard={(card, index) => <CustomCard card={card} index={index} />}
/>
```
