### PR TITLE
Fix: zIndex on children

### DIFF
--- a/Swiper.js
+++ b/Swiper.js
@@ -648,9 +648,12 @@ class Swiper extends Component {
   }
 
   renderChildren = () => {
-    const { childrenOnTop, children } = this.props
+    const { childrenOnTop, children, stackSize, showSecondCard } = this.props
 
-    let zIndex = 1
+    let zIndex = (stackSize && showSecondCard)
+      ? stackSize * -1
+      : 1
+
     if (childrenOnTop) {
       zIndex = 5
     }
@@ -715,6 +718,7 @@ class Swiper extends Component {
         firstCard = false
       }
     }
+
     return renderedCards
   };
 


### PR DESCRIPTION
It seems that all cards since #127 were hidden behind the children, as its zIndex was always `1` and all other cards where `-1`, `-2`, ..., `-n`. Now the zIndex is based on the `stackSize`. So it will show all cards although there is a children.