### PR TITLE
Allows override for container style

### DIFF
--- a/Swiper.js
+++ b/Swiper.js
@@ -792,6 +792,7 @@ Swiper.propTypes = {
   cardStyle: PropTypes.oneOfType([PropTypes.number, PropTypes.object]),
   cardVerticalMargin: PropTypes.number,
   cards: PropTypes.oneOfType([PropTypes.array, PropTypes.object]).isRequired,
+  containerStyle: PropTypes.object,
   children: PropTypes.any,
   childrenOnTop: PropTypes.bool,
   disableBottomSwipe: PropTypes.bool,

--- a/Swiper.js
+++ b/Swiper.js
@@ -640,7 +640,8 @@ class Swiper extends Component {
             backgroundColor: this.props.backgroundColor,
             marginTop: this.props.marginTop,
             marginBottom: this.props.marginBottom
-          }
+          },
+          this.props.containerStyle
         ]}
       >
         {this.renderChildren()}
@@ -863,6 +864,7 @@ Swiper.defaultProps = {
   cardStyle: {},
   cardVerticalMargin: 60,
   childrenOnTop: false,
+  containerStyle: {},
   disableBottomSwipe: false,
   disableLeftSwipe: false,
   disableRightSwipe: false,


### PR DESCRIPTION
I've added a `containerStyle` prop that will allow overrides for the containing `<View>`.  This helps a lot, especially in cases where we have this component inside a screen with others. 