### PR TITLE
Friction/tension props for top card reset animation

### DIFF
--- a/Swiper.js
+++ b/Swiper.js
@@ -913,6 +913,8 @@ Swiper.propTypes = {
   stackSize: PropTypes.number,
   swipeAnimationDuration: PropTypes.number,
   swipeBackCard: PropTypes.bool,
+  topCardResetAnimationFriction: PropTypes.number,
+  topCardResetAnimationTension: PropTypes.number,
   verticalSwipe: PropTypes.bool,
   verticalThreshold: PropTypes.number,
   zoomAnimationDuration: PropTypes.number,

--- a/Swiper.js
+++ b/Swiper.js
@@ -353,7 +353,9 @@ class Swiper extends Component {
 
   resetTopCard = cb => {
     Animated.spring(this.state.pan, {
-      toValue: 0
+      toValue: 0,
+      friction: this.props.topCardResetAnimationFriction,
+      tension: this.props.topCardResetAnimationTension
     }).start(cb)
 
     this.state.pan.setOffset({
@@ -1003,6 +1005,8 @@ Swiper.defaultProps = {
   stackSize: 1,
   swipeAnimationDuration: 350,
   swipeBackCard: false,
+  topCardResetAnimationFriction: 7,
+  topCardResetAnimationTension: 40,
   verticalSwipe: true,
   verticalThreshold: height / 5,
   zoomAnimationDuration: 100,


### PR DESCRIPTION
I wanted to customize the bounciness of the reset animation, so I've made this PR to allow for custom friction/tension values (consistent with other friction/tension props in the codebase). I set the defaultProp values to be the predefined `react-native` defaults, since they weren't previously being set.