### PR TITLE
Remove class style properties to avoid dynamic card style issues

### DIFF
--- a/Swiper.js
+++ b/Swiper.js
@@ -98,7 +98,7 @@ class Swiper extends Component {
     this.state.pan.y.removeAllListeners()
   }
 
-  computeCardStyle = () => {
+  getCardStyle = () => {
     const { height, width } = Dimensions.get('window')
     const {
       cardVerticalMargin,
@@ -111,21 +111,18 @@ class Swiper extends Component {
     const cardHeight =
       height - cardVerticalMargin * 2 - marginTop - marginBottom
 
-    this.cardStyle = {
+    return {
       top: cardVerticalMargin,
       left: cardHorizontalMargin,
       width: cardWidth,
       height: cardHeight
     }
-
-    this.customCardStyle = this.props.cardStyle
-    this.forceUpdate()
   }
 
   initializeCardStyle = () => {
-    this.computeCardStyle()
+    this.forceUpdate();
     Dimensions.addEventListener('change', () => {
-      this.computeCardStyle()
+      this.forceUpdate();
     })
   }
 
@@ -614,7 +611,7 @@ class Swiper extends Component {
 
     return [
       styles.card,
-      this.cardStyle,
+      this.getCardStyle(),
       {
         zIndex: 1,
         opacity: opacity,
@@ -624,23 +621,23 @@ class Swiper extends Component {
           { rotate: rotation }
         ]
       },
-      this.customCardStyle
+      this.props.cardStyle
     ]
   }
 
   calculateStackCardZoomStyle = (position) => [
     styles.card,
-    this.cardStyle,
+    this.getCardStyle(),
     {
       zIndex: position * -1,
       transform: [{ scale: this.state[`stackScale${position}`] }, { translateY: this.state[`stackPosition${position}`] }]
     },
-    this.customCardStyle
+    this.props.cardStyle
   ]
 
   calculateSwipeBackCardStyle = () => [
     styles.card,
-    this.cardStyle,
+    this.getCardStyle(),
     {
       zIndex: 4,
       transform: [
@@ -648,7 +645,7 @@ class Swiper extends Component {
         { translateY: this.state.previousCardY }
       ]
     },
-    this.customCardStyle
+    this.props.cardStyle
   ]
 
   interpolateCardOpacity = () => {


### PR DESCRIPTION
This PR resolves #210

## Result and observation

You should be able to change the `cardStyle` prop at runtime, and see the card style taken into consideration once the cards are rendered again later (using `forceUpdate` on reference ofc).

## To test before and after

Refer to the issue `Step to reproduce` section.
