### PR TITLE
Fix bug where slider clears when reach last card

### DIFF
--- a/Swiper.js
+++ b/Swiper.js
@@ -520,6 +520,8 @@ class Swiper extends Component {
         if (allSwipedCheck()) {
           swipedAllCards = true
         }
+      } else {
+        newCardIndex = 0; 
       }
     }
 


### PR DESCRIPTION
If you have 'infinite' enabled, the stack isn't getting reset when you swipe past the last card.