### PR TITLE
Add view overflow android

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Make sure you set showSecondCard={false} for smoother and proper transitions whi
 | cardStyle            | node   | override swipable card style                       | {}        |
 | containerStyle       | node   | overrides for the containing <View> style          | {}        |
 | pointerEvents        | string | pointerEvents prop for the containing <View>       | 'auto'    |
+| useViewOverflow      | bool   | use ViewOverflow instead of View for the Swiper component |  true     |
 
 ### Swipe back method info
 ## Method

--- a/Swiper.js
+++ b/Swiper.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { PanResponder, Text, View, Dimensions, Animated } from 'react-native'
 import PropTypes from 'prop-types'
 import isEqual from 'lodash/isEqual'
+import ViewOverflow from 'react-native-view-overflow'
 
 import styles from './styles'
 
@@ -510,7 +511,7 @@ class Swiper extends Component {
           swipedAllCards = true
         }
       } else {
-        newCardIndex = 0; 
+        newCardIndex = 0;
       }
     }
 
@@ -688,9 +689,10 @@ class Swiper extends Component {
     })
 
   render = () => {
-    const { pointerEvents, backgroundColor, marginTop, marginBottom, containerStyle, swipeBackCard } = this.props
+    const { pointerEvents, backgroundColor, marginTop, marginBottom, containerStyle, swipeBackCard, useViewOverflow } = this.props
+    const ViewComponent = useViewOverflow ? ViewOverflow : View
     return (
-      <View
+      <ViewComponent
         pointerEvents={pointerEvents}
         style={[
           styles.container,
@@ -705,7 +707,7 @@ class Swiper extends Component {
         {this.renderChildren()}
         {swipeBackCard ? this.renderSwipeBackCard() : null}
         {this.renderStack()}
-      </View>
+      </ViewComponent>
     )
   }
 
@@ -910,7 +912,8 @@ Swiper.propTypes = {
   verticalSwipe: PropTypes.bool,
   verticalThreshold: PropTypes.number,
   zoomAnimationDuration: PropTypes.number,
-  zoomFriction: PropTypes.number
+  zoomFriction: PropTypes.number,
+  useViewOverflow: PropTypes.bool
 }
 
 Swiper.defaultProps = {
@@ -1004,7 +1007,8 @@ Swiper.defaultProps = {
   verticalSwipe: true,
   verticalThreshold: height / 5,
   zoomAnimationDuration: 100,
-  zoomFriction: 7
+  zoomFriction: 7,
+  useViewOverflow: true
 }
 
 export default Swiper

--- a/Swiper.js
+++ b/Swiper.js
@@ -909,11 +909,11 @@ Swiper.propTypes = {
   swipeBackCard: PropTypes.bool,
   topCardResetAnimationFriction: PropTypes.number,
   topCardResetAnimationTension: PropTypes.number,
+  useViewOverflow: PropTypes.bool,
   verticalSwipe: PropTypes.bool,
   verticalThreshold: PropTypes.number,
   zoomAnimationDuration: PropTypes.number,
-  zoomFriction: PropTypes.number,
-  useViewOverflow: PropTypes.bool
+  zoomFriction: PropTypes.number
 }
 
 Swiper.defaultProps = {
@@ -1004,11 +1004,11 @@ Swiper.defaultProps = {
   swipeBackCard: false,
   topCardResetAnimationFriction: 7,
   topCardResetAnimationTension: 40,
+  useViewOverflow: true,
   verticalSwipe: true,
   verticalThreshold: height / 5,
   zoomAnimationDuration: 100,
-  zoomFriction: 7,
-  useViewOverflow: true
+  zoomFriction: 7
 }
 
 export default Swiper

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-deck-swiper",
-    "version": "1.6.4",
+    "version": "1.6.5",
     "description": "Awesome tinder like card swiper for react-native. Highly Customizable!",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     },
     "homepage": "https://github.com/alexbrillant/react-native-deck-swiper#readme",
     "dependencies": {
-        "prop-types": "15.5.10"
+        "prop-types": "15.5.10",
+        "react-native-view-overflow": "0.0.4"
     },
     "peerDependencies": {
         "react": "^16.0.0-beta.5",

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     },
     "homepage": "https://github.com/alexbrillant/react-native-deck-swiper#readme",
     "dependencies": {
-        "prop-types": "15.5.10",
-        "react-native-view-overflow": "0.0.4"
+        "prop-types": "15.5.10"
     },
     "peerDependencies": {
+        "react-native-view-overflow": "0.0.4",
         "react": "^16.0.0-beta.5",
         "react-native": "^0.49.1"
     },


### PR DESCRIPTION
**What this PR solve :** 
When we use the swiper inside a container, cards are truncated during swipe.

**The solution**
To fix this, I used  **ViewOverflow** instead of **View** on the main Swiper container  ( https://github.com/entria/react-native-view-overflow )

The view that would be used by default is `<ViewOverflow/>` but the user could decide to use `<View/>` by adding the props:
 `useViewOverflow={false}`

(I think it's more relevant to do it this way because there is no overflow on IOS by default, so ..we're not expecting it on Android neither)

Example (before using ViewOverflow on Android): 
![badoverflow](https://user-images.githubusercontent.com/9294168/52352274-98ae5400-2a2c-11e9-99e9-a6202cd39c77.gif)

Example with ViewOverflow
![addoverflow](https://user-images.githubusercontent.com/9294168/52352275-9946ea80-2a2c-11e9-9054-0432f30c1b70.gif)

