### PR TITLE
bugfix: reintroduce getDerivedStateFromProps

### DIFF
--- a/Swiper.js
+++ b/Swiper.js
@@ -36,6 +36,15 @@ const rebuildStackAnimatedValues = (props) => {
 }
 
 class Swiper extends Component {
+
+  static getDerivedStateFromProps (props, state) {
+    return {
+      ...state,
+      ...calculateCardIndexes(props.cardIndex, props.cards),
+      cards: props.cards,
+    }
+  }
+
   constructor (props) {
     super(props)
 


### PR DESCRIPTION
After the removal of this method you could no longer update the cards prop. Fixes #244 and #221.

Perhaps @webraptor can throw in his 5 cents as he originally removed it :-)