### PR TITLE
Include changes to children on sCU hook

### DIFF
--- a/Swiper.js
+++ b/Swiper.js
@@ -69,7 +69,8 @@ class Swiper extends Component {
     const { props, state } = this
     const propsChanged = (
       !isEqual(props.cards, nextProps.cards) ||
-      props.cardIndex !== nextProps.cardIndex
+      props.cardIndex !== nextProps.cardIndex ||
+      props.children !== nextState.children
     )
     const stateChanged = (
       nextState.firstCardIndex !== state.firstCardIndex ||

--- a/Swiper.js
+++ b/Swiper.js
@@ -70,7 +70,7 @@ class Swiper extends Component {
     const propsChanged = (
       !isEqual(props.cards, nextProps.cards) ||
       props.cardIndex !== nextProps.cardIndex ||
-      props.children !== nextState.children
+      props.children !== nextProps.children
     )
     const stateChanged = (
       nextState.firstCardIndex !== state.firstCardIndex ||


### PR DESCRIPTION
The `shouldComponentUpdate` does not include changes to the children passed to it. This is a problem because the parent component that calls `<Swiper>` will not have its children rerendered regardless if their props changed.
