### PR TITLE
Switch from react-native-view-overflow to native RN overflow property

### DIFF
--- a/Swiper.js
+++ b/Swiper.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 import { PanResponder, Text, View, Dimensions, Animated } from 'react-native'
 import PropTypes from 'prop-types'
 import isEqual from 'lodash/isEqual'
-import ViewOverflow from 'react-native-view-overflow'
 
 import styles from './styles'
 
@@ -693,11 +692,11 @@ class Swiper extends Component {
 
   render = () => {
     const { pointerEvents, backgroundColor, marginTop, marginBottom, containerStyle, swipeBackCard, useViewOverflow } = this.props
-    const ViewComponent = useViewOverflow ? ViewOverflow : View
     return (
-      <ViewComponent
+      <View
         pointerEvents={pointerEvents}
         style={[
+          {overflow:useViewOverflow ? 'visible' : 'hidden'},
           styles.container,
           {
             backgroundColor: backgroundColor,
@@ -710,7 +709,7 @@ class Swiper extends Component {
         {this.renderChildren()}
         {swipeBackCard ? this.renderSwipeBackCard() : null}
         {this.renderStack()}
-      </ViewComponent>
+      </View>
     )
   }
 

--- a/package.json
+++ b/package.json
@@ -35,9 +35,8 @@
         "prop-types": "15.5.10"
     },
     "peerDependencies": {
-        "react-native-view-overflow": "0.0.4",
         "react": "^16.0.0-beta.5",
-        "react-native": "^0.49.1"
+        "react-native": "^0.57.2"
     },
     "devDependencies": {
         "babel-eslint": "^7.2.3",


### PR DESCRIPTION
Currently `react-native-deck-swiper` depends on an old version of RN which doesn't have native overflow support. Because of this is depends on the `react-native-view-overflow` module to provide it. However this module requires native code, which is unsupported in Expo.

Newer versions of react-native (0.52.2 and up) support overflow natively. I'm not sure if this patch is correct, but it's a start.