### PR TITLE
Move cards prop from state to props; fix lazy loading

### DIFF
--- a/Swiper.js
+++ b/Swiper.js
@@ -98,7 +98,7 @@ class Swiper extends Component {
       responsive
     } = this.props
 
-    if (responsive) return styles.maxSize;
+    if (responsive) return;
 
     const cardWidth = width - cardHorizontalMargin * 2
     const cardHeight =

--- a/Swiper.js
+++ b/Swiper.js
@@ -94,8 +94,11 @@ class Swiper extends Component {
       cardVerticalMargin,
       cardHorizontalMargin,
       marginTop,
-      marginBottom
+      marginBottom,
+      responsive
     } = this.props
+
+    if (responsive) return styles.maxSize;
 
     const cardWidth = width - cardHorizontalMargin * 2
     const cardHeight =

--- a/Swiper.js
+++ b/Swiper.js
@@ -831,13 +831,12 @@ class Swiper extends Component {
     return (
       <Animated.View style={this.calculateOverlayLabelWrapperStyle()}>
         {!overlayLabels[labelType].element &&
-        <Text style={this.calculateOverlayLabelStyle()}>
-          {overlayLabels[labelType].title}
-        </Text>
+          <Text style={this.calculateOverlayLabelStyle()}>
+            {overlayLabels[labelType].title}
+          </Text>
         }
-
         {overlayLabels[labelType].element &&
-        overlayLabels[labelType].element
+          overlayLabels[labelType].element
         }
       </Animated.View>
     )

--- a/styles.js
+++ b/styles.js
@@ -3,7 +3,11 @@ import { StyleSheet } from 'react-native'
 const styles = StyleSheet.create({
   card: {
     flex: 1,
-    position: 'absolute'
+    position: 'absolute',
+  },
+  maxSize: {
+    height: '100%',
+    aspectRatio: 1
   },
   container: {
     alignItems: 'stretch',

--- a/styles.js
+++ b/styles.js
@@ -5,10 +5,6 @@ const styles = StyleSheet.create({
     flex: 1,
     position: 'absolute',
   },
-  maxSize: {
-    height: '100%',
-    aspectRatio: 1
-  },
   container: {
     alignItems: 'stretch',
     position: 'absolute',


### PR DESCRIPTION
Fixes #255 and a couple more similar issues. Basically with this PR, lazy loading is possible by just updating `cards` prop.