### PR TITLE
allSwipedCheck is undefined error

### DIFF
--- a/Swiper.js
+++ b/Swiper.js
@@ -504,13 +504,11 @@ class Swiper extends Component {
 
     this.onSwipedCallbacks(onSwiped)
 
-    allSwipedCheck = () => newCardIndex === this.state.cards.length
-
-    if (allSwipedCheck()) {
+    if (newCardIndex === this.state.cards.length) {
       if (!infinite) {
         this.props.onSwipedAll()
         // onSwipeAll may have added cards
-        if (allSwipedCheck()) {
+        if (newCardIndex === this.state.cards.length) {
           swipedAllCards = true
         }
       } else {


### PR DESCRIPTION
I cloned a fresh version of the repo and currently on version `^v1.6.7`. I came across a bug where the allSwipedCheck was undefined because in the codebase in the `incrementCardIndex()` there was a code snippet like this:

```javascript
allSwipedCheck = () => newCardIndex === this.state.cards.length;
```

However, the variable is never initialized or declared or even defined prior. So I checked if it was used anywhere else and noticed that it is only used for the 2 if statements right below the assignment. 

Solution: Remove the assignment and place the condition into both if statements.